### PR TITLE
make 'OBJECTSYMBOL's affect whole group of items with same description

### DIFF
--- a/src/options.c
+++ b/src/options.c
@@ -1129,6 +1129,7 @@ const char *str;
        char object[BUFSZ];
        char codepoint[BUFSZ];
        int i, num=0;
+       boolean found=FALSE;
 
        if (!parse_extended_option(str, object, codepoint)) {
                return FALSE;
@@ -1147,17 +1148,17 @@ const char *str;
                         * descriptive name. */
                        if (!strcmpi(object, obj_descr[i].oc_descr)) {
                                objclass_unicode_codepoint[i] = num;
-                               return TRUE;
+                               found = TRUE;
                        }
                } else if (obj_descr[i].oc_name) {
                        /* items with only actual name like "carrot" */
                        if (!strcmpi(object, obj_descr[i].oc_name)) {
                                objclass_unicode_codepoint[i] = num;
-                               return TRUE;
+                               found = TRUE;
                        }
                }
        }
-       return FALSE;
+       return found;
 }
 
 


### PR DESCRIPTION
Without this fix, if you try to set an OBJECTSYMBOL for 'bag', like:

OBJECTSYMBOL='bag':0x0263

it would only affect the first matching object, which is the 'sack'.

This problematic for the following reasons:
- There is effectively no way to set the symbol for 'oilskin sack',
  'bag of holding', or 'bag of tricks'. They will always be displayed
  as if the OBJECTSYMBOL didn't exist.
- It gives a way to visually distinguish a plain 'sack' from a better
  item without identifying it in any way.

The same problem exists for other object groups, like 'flute',
'horn', 'drum', etc.
